### PR TITLE
Add stdout to save model_uri with no copy-paste

### DIFF
--- a/convert_gptj.py
+++ b/convert_gptj.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import shutil
 import tarfile
 import argparse
@@ -54,7 +55,8 @@ def convert(bucket_name="hf-sagemaker-inference"):
     )
     model_uri = upload_file_to_s3(bucket_name=bucket_name, key_prefix=key_prefix)
     print(f"Successfully uploaded to {model_uri}")
-
+    
+    sys.stdout.write(model_uri)
     return model_uri
 
 


### PR DESCRIPTION
Added a sys.stdout call on return, so that the model_uri can be captured from a terminal or jupyter notebook environment, removing the need for copy pasting.

E.g:
In Jupyter:
output = ! python3 convert_gptj.py --bucket_name {model_storage}
model_uri = output[0]

In terminal: 
model_uri=`python3 convert_gptj.py --bucket_name {model_storage}`