### PR TITLE
Update model name from EleutherAI/gpt-j-6B to EleutherAI/gpt-j-6b

### DIFF
--- a/convert_gptj.py
+++ b/convert_gptj.py
@@ -30,7 +30,7 @@ def convert(bucket_name="hf-sagemaker-inference"):
     os.makedirs(dst_inference_script, exist_ok=True)
 
     # load fp 16 model
-    print("Loading model from `EleutherAI/gpt-j-6B`")
+    print("Loading model from `EleutherAI/gpt-j-6b`")
     model = GPTJForCausalLM.from_pretrained(
         "EleutherAI/gpt-j-6B", revision="float16", torch_dtype=torch.float16
     )
@@ -38,7 +38,7 @@ def convert(bucket_name="hf-sagemaker-inference"):
     torch.save(model, os.path.join(model_save_dir, "gptj.pt"))
 
     print("saving tokenizer")
-    tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-j-6B")
+    tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-j-6b")
     tokenizer.save_pretrained(model_save_dir)
 
     # copy inference script


### PR DESCRIPTION
I was reading your blog regarding how to deploy GPT-J to AWS sagemaker and you provided this awesome convert.

However per transformer version 4.12.3 (the version in this repo) it will raise the following error 

---

OSError: Can't load config for 'EleutherAI/gpt-j-6B'. Make sure that:

- 'EleutherAI/gpt-j-6B' is a correct model identifier listed on 'https://huggingface.co/models'
  (make sure 'EleutherAI/gpt-j-6B' is not a path to a local directory with something else, in that case)

- or 'EleutherAI/gpt-j-6B' is the correct path to a directory containing a config.json file

- or 'float16' is a valid git identifier (branch name, a tag name, or a commit id) that exists for this model name as listed on its model page on 'https://huggingface.co/models'

---
and many people are reporting it : https://huggingface.co/EleutherAI/gpt-j-6b/discussions/23


I fixed the issue using 'EleutherAI/gpt-j-6b' instead so it is small b

Thank you